### PR TITLE
Add alternate light entry

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,0 +1,81 @@
+import React from 'react';
+
+const Text = ({ children }) => <span>{children}</span>;
+
+function createStyleObject(classNames, style) {
+  return classNames.reduce((styleObject, className) => {
+    return {...styleObject, ...style[className]};
+  }, {});
+}
+
+function createClassNameString(classNames) {
+  return classNames.join(' ');
+}
+
+function createChildren(style, useInlineStyles) {
+  let childrenCount = 0;
+  return children => {
+    childrenCount += 1;
+    return children.map((child, i) => createElement({
+      node: child,
+      style,
+      useInlineStyles,
+      key:`code-segment-${childrenCount}-${i}`
+    }));
+  }
+}
+
+function createElement({ node, style, useInlineStyles, key }) {
+  const { properties, type, tagName, value } = node;
+  if (type === "text") {
+    return <Text key={key}>{ value }</Text>;
+  } else if (tagName) {
+    const TagName = tagName;
+    const childrenCreator = createChildren(style, useInlineStyles);
+    const props = (
+      useInlineStyles
+      ?
+      { style: createStyleObject(properties.className, style) }
+      :
+      { className: createClassNameString(properties.className) }
+    );
+    const children = childrenCreator(node.children);
+    return <TagName key={key} {...props}>{children}</TagName>;
+  }
+}
+
+export default function (lowlight, defaultStyle) {
+ return function SyntaxHighlighter(props) {
+    const {
+      language,
+      children,
+      style = defaultStyle,
+      customStyle = {},
+      codeTagProps = {},
+      useInlineStyles = true,
+      ...rest
+    } = props;
+    const codeTree = lowlight.highlight(language, children);
+    const defaultPreStyle = style.hljs || {backgroundColor: '#fff'};
+    const preProps = (
+      useInlineStyles
+      ?
+      Object.assign({}, rest, { style: Object.assign({}, defaultPreStyle, customStyle) })
+      :
+      Object.assign({}, rest, { className: 'hljs'})
+    );
+
+    return (
+      <pre {...preProps}>
+        <code {...codeTagProps}>
+          {codeTree.value.map((node, i) => createElement({
+            node,
+            style,
+            useInlineStyles,
+            key: `code-segement${i}`
+          }))}
+        </code>
+      </pre>
+    );
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
-import React from 'react';
 let defaultStyle = {};
 let lowlight;
+
+import highlight from './highlight';
+
 if (process.env.REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD) {
 	lowlight = require('lowlight/lib/core');
 } else {
@@ -8,80 +10,4 @@ if (process.env.REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD) {
 	lowlight = require('lowlight');
 }
 
-const Text = ({ children }) => <span>{children}</span>;
-
-function createStyleObject(classNames, style) {
-	return classNames.reduce((styleObject, className) => {
-		return {...styleObject, ...style[className]};
-	}, {});
-}
-
-function createClassNameString(classNames) {
-	return classNames.join(' ');
-}
-
-function createChildren(style, useInlineStyles) {
-	let childrenCount = 0;
-	return children => {
-		childrenCount += 1;
-		return children.map((child, i) => createElement({
-			node: child, 
-			style, 
-			useInlineStyles,
-			key:`code-segment-${childrenCount}-${i}`
-		}));
-	}
-}
-
-function createElement({ node, style, useInlineStyles, key }) {
-	const { properties, type, tagName, value } = node;
-	if (type === "text") {
-		return <Text key={key}>{ value }</Text>;
-	} else if (tagName) {
-		const TagName = tagName;
-		const childrenCreator = createChildren(style, useInlineStyles);
-		const props = (
-			useInlineStyles 
-			? 
-			{ style: createStyleObject(properties.className, style) }
-			:
-			{ className: createClassNameString(properties.className) }
-		);
-		const children = childrenCreator(node.children);
-		return <TagName key={key} {...props}>{children}</TagName>;
-	}
-}
-
-export default function SyntaxHighlighter(props) {
-	const {
-		language, 
-		children, 
-		style = defaultStyle, 
-		customStyle = {}, 
-		codeTagProps = {},
-		useInlineStyles = true, 
-		...rest
-	} = props;
-	const codeTree = lowlight.highlight(language, children);
-	const defaultPreStyle = style.hljs || {backgroundColor: '#fff'};
-	const preProps = (
-		useInlineStyles 
-		? 
-		Object.assign({}, rest, { style: Object.assign({}, defaultPreStyle, customStyle) })
-		:
-		Object.assign({}, rest, { className: 'hljs'})
-	);
-
-	return (
-		<pre {...preProps}>
-			<code {...codeTagProps}>
-				{codeTree.value.map((node, i) => createElement({
-					node, 
-					style,
-					useInlineStyles, 
-					key: `code-segement${i}`
-				}))}
-			</code>
-		</pre>
-	);
-}
+export default highlight(lowlight, defaultStyle);

--- a/src/light.js
+++ b/src/light.js
@@ -1,0 +1,8 @@
+let defaultStyle = {};
+let lowlight;
+
+import highlight from './highlight';
+
+lowlight = require('lowlight/lib/core');
+
+export default highlight(lowlight, defaultStyle);

--- a/src/light.js
+++ b/src/light.js
@@ -1,8 +1,6 @@
-let defaultStyle = {};
-let lowlight;
-
 import highlight from './highlight';
+import lowlight from 'lowlight/lib/core';
 
-lowlight = require('lowlight/lib/core');
+const defaultStyle = {};
 
 export default highlight(lowlight, defaultStyle);


### PR DESCRIPTION
This allows for `import SyntaxHighlighter from "react-syntax-highlight/dist/light"` without the need for changing webpack/browserify configs at all. Thoughts?