### PR TITLE
export lowlight registerLanguage function in light build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,29 +43,15 @@ const Component = () => {
 ```
 ### Light Build
 
-React Syntax Highlighter used in the way described above can have a fairly large footprint. For those that desire more control over what exactly they need, there is the option to use an envified light build via the env variable `REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD`. If you choose to use this you will need to specifically import lowlight and register your desired language and specifically import that language from highlight js. Then using something like `envify` for browserify or `DefinePlugin` for webpack pass the env `REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD` into your build. You'll also want to import the style of your choosing from the specified file directly instead of /dist/styles index. An example for using with webpack can be found below:
+React Syntax Highlighter used in the way described above can have a fairly large footprint. For those that desire more control over what exactly they need, there is an option to import a light build. If you choose to use this you will need to specifically import desired languages and register them using the registerLanguage export from the light build.
 
 ```js
+import SyntaxHighlighter, { registerLanguage } from "react-syntax-highlighter/dist/light"
 import js from 'highlight.js/lib/languages/javascript';
-import lowlight from 'lowlight/lib/core';
 import docco from 'react-syntax-highlighter/dist/styles/docco'; 
 
-lowlight.registerLanguage('javascript', js);
+registerLanguage('javascript', js);
 ```
-
-Then in your webpack config: 
-
-```js
-  plugins: [
-    new webpack.DefinePlugin({
-      "process.env.REACT_SYNTAX_HIGHLIGHTER_LIGHT_BUILD": true,
-      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)
-    })
-  ]
-```
-
-Alternatively you can `import SyntaxHighlighter from "react-syntax-highlighter/dist/light"` to require the light build directly.
-
 ### Built with React Syntax Highlighter
 
 - [DBGlass](https://github.com/web-pal/DBGlass) - PostgreSQL client built with Electron.

--- a/src/light.js
+++ b/src/light.js
@@ -3,4 +3,5 @@ import lowlight from 'lowlight/lib/core';
 
 const defaultStyle = {};
 
+export const registerLanguage = lowlight.registerLanguage;
 export default highlight(lowlight, defaultStyle);


### PR DESCRIPTION
update readme to point to exported registerLanaguage function 

also update language in README to refer directly to the imported light build and remove envified build info from the README in preparation to remove that functionality

@bmathews could you took a look.

Unfortunately will still need to import the language from highlight.js but this is a step in the right direction I think