### PR TITLE
only default wrapLines to true if undefined

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -118,15 +118,16 @@ export default function (lowlight, defaultStyle) {
   startingLineNumber = 1,
   lineNumberContainerStyle,
   lineNumberStyle,
-  wrapLines = false,
+  wrapLines,
   lineStyle = {},
   renderer,
   ...rest
  }) {
-    /* custom renderers rely on individual row elements so we need to turn wrapLines on 
-     * if renderer is provided
+    /* 
+     * some custom renderers rely on individual row elements so we need to turn wrapLines on 
+     * if renderer is provided and wrapLines is undefined
     */
-    wrapLines = renderer ? true : wrapLines;
+    wrapLines = renderer && wrapLines === undefined ? true : wrapLines;
     renderer = renderer || defaultRenderer;
     const codeTree = (
       language ? 


### PR DESCRIPTION
when using custom renderer

I think this will be a fair middle ground between too much comingled configuration when using virtualized renderer for example, and not overriding an explicitly set user option. it might be nice for the renderer itself to have a say in some of the options but i haven't thought much about how that would actually work in practice 