### PR TITLE
fix line wrapping by first flattening the tree before splitting new lines

### DIFF
--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -24,16 +24,22 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         const
       </span>
-       woah = 
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          fun
-        </span>
+         woah = 
+      </span>
+      <span
+        style={Object {}}>
+        fun
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       fun + 
+      <span
+        style={Object {}}>
+         fun + 
+      </span>
       <span
         style={
           Object {
@@ -59,7 +65,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         const
       </span>
-       dude = woah(
+      <span
+        style={Object {}}>
+         dude = woah(
+      </span>
       <span
         style={
           Object {
@@ -68,7 +77,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         2
       </span>
-      ) + 
+      <span
+        style={Object {}}>
+        ) + 
+      </span>
       <span
         style={
           Object {
@@ -87,28 +99,32 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }
       }>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          thisIsAFunction
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        thisIsAFunction
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -126,9 +142,12 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       [
+      <span
+        style={Object {}}>
+         [
+      </span>
       <span
         style={
           Object {
@@ -137,7 +156,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         1
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -146,7 +168,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         2
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -155,16 +180,22 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         3
       </span>
-      ].map(
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          n
-        </span>
+        ].map(
+      </span>
+      <span
+        style={Object {}}>
+        n
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       n + 
+      <span
+        style={Object {}}>
+         n + 
+      </span>
       <span
         style={
           Object {
@@ -173,7 +204,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         1
       </span>
-      ).filter(n !== 
+      <span
+        style={Object {}}>
+        ).filter(n !== 
+      </span>
       <span
         style={
           Object {
@@ -208,7 +242,10 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }>
         console
       </span>
-      .log(
+      <span
+        style={Object {}}>
+        .log(
+      </span>
       <span
         style={
           Object {
@@ -236,28 +273,32 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
         }
       }>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          itIs
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        itIs
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -275,9 +316,12 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       
+      <span
+        style={Object {}}>
+         
+      </span>
       <span
         style={
           Object {
@@ -337,16 +381,22 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         const
       </span>
-       woah = 
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          fun
-        </span>
+         woah = 
+      </span>
+      <span
+        style={Object {}}>
+        fun
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       fun + 
+      <span
+        style={Object {}}>
+         fun + 
+      </span>
       <span
         style={
           Object {
@@ -372,7 +422,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         const
       </span>
-       dude = woah(
+      <span
+        style={Object {}}>
+         dude = woah(
+      </span>
       <span
         style={
           Object {
@@ -381,7 +434,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         2
       </span>
-      ) + 
+      <span
+        style={Object {}}>
+        ) + 
+      </span>
       <span
         style={
           Object {
@@ -400,28 +456,32 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }
       }>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          thisIsAFunction
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        thisIsAFunction
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -439,9 +499,12 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       [
+      <span
+        style={Object {}}>
+         [
+      </span>
       <span
         style={
           Object {
@@ -450,7 +513,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         1
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -459,7 +525,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         2
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -468,16 +537,22 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         3
       </span>
-      ].map(
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          n
-        </span>
+        ].map(
+      </span>
+      <span
+        style={Object {}}>
+        n
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       n + 
+      <span
+        style={Object {}}>
+         n + 
+      </span>
       <span
         style={
           Object {
@@ -486,7 +561,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         1
       </span>
-      ).filter(n !== 
+      <span
+        style={Object {}}>
+        ).filter(n !== 
+      </span>
       <span
         style={
           Object {
@@ -521,7 +599,10 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }>
         console
       </span>
-      .log(
+      <span
+        style={Object {}}>
+        .log(
+      </span>
       <span
         style={
           Object {
@@ -549,28 +630,32 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
         }
       }>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          itIs
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        itIs
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -588,9 +673,12 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       
+      <span
+        style={Object {}}>
+         
+      </span>
       <span
         style={
           Object {
@@ -646,16 +734,22 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         const
       </span>
-       woah = 
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          fun
-        </span>
+         woah = 
+      </span>
+      <span
+        style={Object {}}>
+        fun
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       fun + 
+      <span
+        style={Object {}}>
+         fun + 
+      </span>
       <span
         style={
           Object {
@@ -677,7 +771,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         const
       </span>
-       dude = woah(
+      <span
+        style={Object {}}>
+         dude = woah(
+      </span>
       <span
         style={
           Object {
@@ -686,7 +783,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         2
       </span>
-      ) + 
+      <span
+        style={Object {}}>
+        ) + 
+      </span>
       <span
         style={
           Object {
@@ -701,28 +801,32 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
     <span
       style={Object {}}>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          thisIsAFunction
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        thisIsAFunction
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -736,9 +840,12 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       [
+      <span
+        style={Object {}}>
+         [
+      </span>
       <span
         style={
           Object {
@@ -747,7 +854,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         1
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -756,7 +866,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         2
       </span>
-      ,
+      <span
+        style={Object {}}>
+        ,
+      </span>
       <span
         style={
           Object {
@@ -765,16 +878,22 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         3
       </span>
-      ].map(
       <span
         style={Object {}}>
-        <span
-          style={Object {}}>
-          n
-        </span>
+        ].map(
+      </span>
+      <span
+        style={Object {}}>
+        n
+      </span>
+      <span
+        style={Object {}}>
          =>
       </span>
-       n + 
+      <span
+        style={Object {}}>
+         n + 
+      </span>
       <span
         style={
           Object {
@@ -783,7 +902,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         1
       </span>
-      ).filter(n !== 
+      <span
+        style={Object {}}>
+        ).filter(n !== 
+      </span>
       <span
         style={
           Object {
@@ -810,7 +932,10 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
         }>
         console
       </span>
-      .log(
+      <span
+        style={Object {}}>
+        .log(
+      </span>
       <span
         style={
           Object {
@@ -830,28 +955,32 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
     <span
       style={Object {}}>
       <span
+        style={
+          Object {
+            "fontWeight": "bold"
+          }
+        }>
+        function
+      </span>
+      <span
         style={Object {}}>
-        <span
-          style={
-            Object {
-              "fontWeight": "bold"
-            }
-          }>
-          function
-        </span>
          
-        <span
-          style={
-            Object {
-              "color": "#880000",
-              "fontWeight": "bold"
-            }
-          }>
-          itIs
-        </span>
+      </span>
+      <span
+        style={
+          Object {
+            "color": "#880000",
+            "fontWeight": "bold"
+          }
+        }>
+        itIs
+      </span>
+      <span
+        style={Object {}}>
         (
-        <span
-          style={Object {}} />
+      </span>
+      <span
+        style={Object {}}>
         ) 
       </span>
       {
@@ -865,9 +994,12 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
             "fontWeight": "bold"
           }
         }>
-          return
+        return
       </span>
-       
+      <span
+        style={Object {}}>
+         
+      </span>
       <span
         style={
           Object {

--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -142,7 +142,7 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>
@@ -316,7 +316,7 @@ exports[`test SyntaxHighlighter allows lineStyle as function 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>
@@ -499,7 +499,7 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>
@@ -673,7 +673,7 @@ exports[`test SyntaxHighlighter allows lineStyle as object 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>
@@ -840,7 +840,7 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>
@@ -994,7 +994,7 @@ exports[`test SyntaxHighlighter component renders correctly 1`] = `
             "fontWeight": "bold"
           }
         }>
-        return
+          return
       </span>
       <span
         style={Object {}}>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -92,7 +92,11 @@ function wrapLinesInSpan(codeTree, lineStyle) {
           ).concat(newChild);
           newTree.push(createLineElement({ children, lineNumber, lineStyle })); 
         } else if (i === splitValue.length - 1) {
-          const stringChild = tree[index + 1];
+          const stringChild = (
+            tree[index + 1] && 
+            tree[index + 1].children && 
+            tree[index + 1].children[0]
+          );
           if (stringChild) {
             stringChild.value = `${text}${stringChild.value}`;
           } else {
@@ -106,8 +110,8 @@ function wrapLinesInSpan(codeTree, lineStyle) {
     }
     return { newTree, lastLineBreakIndex };
   }, { newTree: [], lastLineBreakIndex: -1 });
-  if (lastLineBreakIndex !== codeTree.value.length - 1) {
-    const children = codeTree.value.slice(lastLineBreakIndex + 1, codeTree.value.length);
+  if (lastLineBreakIndex !== tree.length - 1) {
+    const children = tree.slice(lastLineBreakIndex + 1, tree.length);
     if (children && children.length) {
       newTree.push(createLineElement({ children, lineNumber: newTree.length + 1, lineStyle })); 
     }


### PR DESCRIPTION
closes #63

@bmathews  believe i've found a better long term solution to wrapping individual lines by first flattening the code tree to an array of only single child span elements. This gives us guarantees when reducing over the tree that every element has the same signature of span + 1 child which is text making a lot easier to catch edge cases. 

Let me know if you time to take a look, thanks (specifically this commit -- https://github.com/conorhastings/react-syntax-highlighter/pull/64/commits/25e931892d22bf8f4fe8319e96135096e8b24344)