### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules
 demo
 npm-debug.log
 .DS_Store
+.babelrc


### PR DESCRIPTION
This is needed in order to use this module with parcel without installing all babel plugins this module uses.