### PR TITLE
Handle fs errors

### DIFF
--- a/lib/build-languages-highlightjs.js
+++ b/lib/build-languages-highlightjs.js
@@ -22,21 +22,33 @@ function createLanguagePassthroughModule (file) {
     ''
   ];
 
-  fs.writeFile(path.join(__dirname, `../src/languages/hljs/${file}`), lines.join(';\n'));
+  fs.writeFile(path.join(__dirname, `../src/languages/hljs/${file}`), lines.join(';\n'), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 }
 
 fs.readdir(path.join(__dirname, '../node_modules/highlight.js/lib/languages'), (err, files) => {
   if (err) {
-    process.exit(1);
+    throw err;
   }
-  
+
   files.forEach(createLanguagePassthroughModule);
 
   const availableLanguageNames = files.map((file) => file.split('.js')[0]);
   const languagesLi = availableLanguageNames.map((name) => `\n* ${makeImportName(name)}${ makeImportName(name) !== name ? ` (${name})` : '' }`);
   const languageMD = `## Available \`language\` imports ${languagesLi.join('')}`;
-  fs.writeFile(path.join(__dirname, '../AVAILABLE_LANGUAGES_HLJS.MD'), languageMD);
+  fs.writeFile(path.join(__dirname, '../AVAILABLE_LANGUAGES_HLJS.MD'), languageMD, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 
   const defaultExports = availableLanguageNames.map((name) => `export { default as ${makeImportName(name)} } from './${name}';\n`);
-  fs.writeFile(path.join(__dirname, '../src/languages/hljs/index.js'), defaultExports.join(''));
+  fs.writeFile(path.join(__dirname, '../src/languages/hljs/index.js'), defaultExports.join(''), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 });

--- a/lib/build-stylesheets-highlightjs.js
+++ b/lib/build-stylesheets-highlightjs.js
@@ -8,7 +8,10 @@ const css = require('css');
 const camel = require('to-camel-case');
 
 fs.readdir(path.join(__dirname, '../node_modules/highlight.js/styles'), (err, files) => {
- 
+  if (err) {
+    throw err;
+  }
+
   files.forEach(file => {
     let stylesList = [];
     if (file.includes('.css')) {
@@ -22,8 +25,16 @@ fs.readdir(path.join(__dirname, '../node_modules/highlight.js/styles'), (err, fi
   const styles = availableStyleNames.map(name => `\n* ${camel(name)}`);
   const defaultExports = availableStyleNames.map(name => `export { default as ${camel(name)} } from './${name}';\n`);
   const styleMD = `## Available \`stylesheet\` props ${styles.join('')}`;
-  fs.writeFile(path.join(__dirname, '../AVAILABLE_STYLES_HLJS.MD'), styleMD);
-  fs.writeFile(path.join(__dirname, '../src/styles/hljs/index.js'), defaultExports.join(''));
+  fs.writeFile(path.join(__dirname, '../AVAILABLE_STYLES_HLJS.MD'), styleMD, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+  fs.writeFile(path.join(__dirname, '../src/styles/hljs/index.js'), defaultExports.join(''), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 });
 
 
@@ -31,6 +42,9 @@ function createJavascriptStyleSheet(file) {
   const ignoreStyleWithThis = '.hljs a';
   const fileWithoutCSS = file.split('.css')[0] === 'default' ? 'default-style' : file.split('.css')[0];
   fs.readFile(path.join(__dirname, `../node_modules/highlight.js/styles/${file}`), 'utf-8', (err, data) => {
+    if (err) {
+      throw err;
+    }
     const javacriptStylesheet = css.parse(data).stylesheet.rules.reduce((sheet, rule) => {
       if (rule.type === 'rule') {
         const style = rule.selectors.reduce((selectors, selector) => {
@@ -41,7 +55,7 @@ function createJavascriptStyleSheet(file) {
               }
               return declarations;
             }, {});
-            selectors[selector.substring(1)] = selectorObject;              
+            selectors[selector.substring(1)] = selectorObject;
           }
           return selectors;
         }, {});
@@ -57,7 +71,12 @@ function createJavascriptStyleSheet(file) {
       }
       return sheet;
     }, {});
-    fs.writeFile(path.join(__dirname, `../src/styles/hljs/${fileWithoutCSS}.js`), 
-      `export default ${JSON.stringify(javacriptStylesheet, null, 4)}`);
+    fs.writeFile(path.join(__dirname, `../src/styles/hljs/${fileWithoutCSS}.js`),
+      `export default ${JSON.stringify(javacriptStylesheet, null, 4)}`,
+      (err) => {
+        if (err) {
+          throw err;
+        }
+      });
   });
 }


### PR DESCRIPTION
This makes sure the errors will not be silently swallowed. This is deprecated behavior since a long time and it will throw from Node.js 10.x on. By throwing the error itself instead of just ending the process it is also easier to understand what is going on.

For further information see https://github.com/nodejs/node/pull/18668.