### PR TITLE
Removed vscodethemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ registerLanguage('jsx', jsx);
 - [React Component Demo](https://github.com/conorhastings/react-component-demo) - A React Component To make live editable demos of other React Components.
 - [Redux Test Recorder](https://github.com/conorhastings/redux-test-recorder) - a redux middleware to automatically generate tests for reducers through ui interaction. Syntax highlighter used by react plugin.
 - [GitPoint](https://github.com/gitpoint/git-point) - GitHub for iOS. Built with React Native. (built using react-native-syntax-highlighter)
-- [vscodethemes](https://vscodethemes.com/) - A website for viewing vscode themes online using react-syntax-highlighter
 - [Yoga Layout Playground](https://yogalayout.com/playground) - generate code for yoga layout in multiple languages
 - [Kibana](https://github.com/elastic/kibana) - browser-based analytics and search dashboard for Elasticsearch.
 ### License


### PR DESCRIPTION
Hey! I pushed some big changes to the site and am no longer using your awesome component. 

The previews were horribly wrong because I was converting textmate themes to PrismJS themes. I'm now using vscode's tokenizer to pre-render the language previews with accurate syntax highlighting.

Figured you wouldn't want the reference in the README anymore. 

I do very much appreciate the link and the great work on the component—it was super easy to setup.

Cheers