### PR TITLE
Export createElement from light module

### DIFF
--- a/src/light.js
+++ b/src/light.js
@@ -3,3 +3,4 @@ import lowlight from 'lowlight/lib/core';
 
 export const registerLanguage = lowlight.registerLanguage;
 export default highlight(lowlight, {});
+export { default as createElement } from './create-element';


### PR DESCRIPTION
Allows using createElement easily when using the light build, without pulling in all languages.