### PR TITLE
Add sideEffects false to package.json to fix tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "syntax highlighting component for react with prismjs or highlightjs ast using inline styles",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "sideEffects": false,
   "dependencies": {
     "babel-runtime": "^6.18.0",
     "highlight.js": "~9.12.0",


### PR DESCRIPTION
Fixes #150 , I checked the dependencies and couldn't find a obvious reason for tree shaking not to work and the demo still works. Sometimes if the module depends on a unused import, like:

```
import 'myStyleOverrides';
```

It will break because webpack will tree shake out that import if the sideEffects: false flag is present.
But I couldn't find any, so I think this fix should be good to go.