### PR TITLE
Expose supportedLanguages on a static field

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Highlight version
 import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
 ```
 
+#### Supported languages
+Access via the `supportedLanguages` static field.
+```js
+SyntaxHighlighter.supportedLanguages
+```
+
 ### Built with React Syntax Highlighter
 
 - [mdx-deck](https://github.com/jxnblk/mdx-deck) - MDX-based presentation decks

--- a/__tests__/async-syntax-highlighter.js
+++ b/__tests__/async-syntax-highlighter.js
@@ -75,12 +75,12 @@ test('AsyncSyntaxHighlighter loadAstGenerator should return the promise of the l
 
 test('AsyncSyntaxHighlighter loadAstGenerator when astGenerator resolves', async () => {
   const astGenerator = "test";
-  const loader = jest.fn().mockResolvedValue(astGenerator)
+  const loader = jest.fn().mockResolvedValue(astGenerator);
   
   
   const SyntaxHighlighter = AsyncSyntaxHighlighter({ loader });
   await SyntaxHighlighter.loadAstGenerator();
-  expect(SyntaxHighlighter.astGenerator).toEqual(astGenerator)
+  expect(SyntaxHighlighter.astGenerator).toEqual(astGenerator);
 });
 
 test('AsyncSyntaxHighlighter loadAstGenerator when astGenerator resolves and it has languages in the language array', async () => {
@@ -95,5 +95,32 @@ test('AsyncSyntaxHighlighter loadAstGenerator when astGenerator resolves and it 
   SyntaxHighlighter.languages.set(testLanguage.name, testLanguage.language)
 
   await SyntaxHighlighter.loadAstGenerator();
-  expect(registerLanguage).toBeCalledWith(astGenerator, testLanguage.name, testLanguage.language)
+  expect(registerLanguage).toBeCalledWith(astGenerator, testLanguage.name, testLanguage.language);
+});
+
+test('AsyncSyntaxHighlighter when a supportedLanguages array is passed in it should be set to the supported languages static field', () => {
+  const supportedLanguages = [ "test" ];
+  const registerLanguage = jest.fn();
+  const languageLoaders = {
+    "foo": () => "bar"
+  };
+  const astGenerator = "test";
+  const loader = jest.fn().mockResolvedValue(astGenerator)
+  
+  const SyntaxHighlighter = AsyncSyntaxHighlighter({ loader, registerLanguage, languageLoaders, supportedLanguages });
+  
+  expect(SyntaxHighlighter.supportedLanguages).toEqual(supportedLanguages);
+});
+
+test('AsyncSyntaxHighlighter when language loaders are passed in, it should set the keys to the supported languages static field', () => {
+  const registerLanguage = jest.fn();
+  const languageLoaders = {
+    "foo": () => "bar"
+  };
+  const astGenerator = "test";
+  const loader = jest.fn().mockResolvedValue(astGenerator)
+  
+  const SyntaxHighlighter = AsyncSyntaxHighlighter({ loader, registerLanguage, languageLoaders });
+  
+  expect(SyntaxHighlighter.supportedLanguages).toEqual([ "foo" ]);
 });

--- a/lib/build-languages-highlightjs.js
+++ b/lib/build-languages-highlightjs.js
@@ -36,6 +36,21 @@ function createAsyncLanguageLoadersIndex(files) {
   });
 }
 
+function createSupportedLanguagesArray(files) {
+  let lines = [
+    `export default [`
+  ];
+
+  lines = lines.concat(files.map( file => `'${file.split('.js')[0]}',` ));
+  lines.push(`]`)
+  
+  fs.writeFile(path.join(__dirname, `../src/languages/hljs/supported-languages.js`), lines.join('\n'), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+}
+
 function createLanguagePassthroughModule (file) {
   const fileWithoutJS = file.split('.js')[0];
   const importName = makeImportName(fileWithoutJS);
@@ -58,8 +73,9 @@ fs.readdir(path.join(__dirname, '../node_modules/highlight.js/lib/languages'), (
   }
 
   files.forEach(createLanguagePassthroughModule);
-  // files.forEach(createLanguageAsyncLoaderModule);
+  
   createAsyncLanguageLoadersIndex(files);
+  createSupportedLanguagesArray(files);
 
   const availableLanguageNames = files.map((file) => file.split('.js')[0]);
   const languagesLi = availableLanguageNames.map((name) => `\n* ${makeImportName(name)}${ makeImportName(name) !== name ? ` (${name})` : '' }`);

--- a/lib/build-languages-refractor.js
+++ b/lib/build-languages-refractor.js
@@ -35,6 +35,21 @@ function createAsyncLanguageLoaderLine(file) {
   return `  ${importName}: createLanguageAsyncLoader("${importName}", () => import(/* webpackChunkName: "react-syntax-highlighter_languages_refractor_${importName}" */ "refractor/lang/${file}")),`;
 }
 
+function createSupportedLanguagesArray(files) {
+  let lines = [
+    `export default [`
+  ];
+
+  lines = lines.concat(files.map( file => `'${file.split('.js')[0]}',` ));
+  lines.push(`]`)
+  
+  fs.writeFile(path.join(__dirname, `../src/languages/prism/supported-languages.js`), lines.join('\n'), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+}
+
 function createAsyncLanguageLoadersIndex(files) {
   let lines = [
     `import createLanguageAsyncLoader from "./create-language-async-loader"`,
@@ -57,7 +72,10 @@ fs.readdir(path.join(__dirname, '../node_modules/refractor/lang'), (err, files) 
     process.exit(1);
   }
   files.forEach(createLanguagePassthroughModule);
+  
   createAsyncLanguageLoadersIndex(files);
+  createSupportedLanguagesArray(files);
+
   const availableLanguageNames = files.map(file => file.split('.js')[0]);
   console.log(availableLanguageNames.join('\n'));
   const languagesLi = availableLanguageNames.map((name) => `\n* ${makeImportName(name)}${ makeImportName(name) !== name ? ` (${name})` : '' }`);

--- a/src/async-syntax-highlighter.js
+++ b/src/async-syntax-highlighter.js
@@ -15,6 +15,7 @@ export default (options) => {
     static highlightInstance = (highlight(null, {}));
     static astGeneratorPromise = null;
     static languages = new Map();
+    static supportedLanguages = Object.keys(languageLoaders);
 
     static preload() {
       return ReactAsyncHighlighter.loadAstGenerator();

--- a/src/async-syntax-highlighter.js
+++ b/src/async-syntax-highlighter.js
@@ -7,7 +7,7 @@ export default (options) => {
     isLanguageRegistered, 
     registerLanguage, 
     languageLoaders, 
-    noAsyncLoadingLanguages 
+    noAsyncLoadingLanguages,
   } = options;
 
   class ReactAsyncHighlighter extends React.PureComponent {
@@ -15,7 +15,7 @@ export default (options) => {
     static highlightInstance = (highlight(null, {}));
     static astGeneratorPromise = null;
     static languages = new Map();
-    static supportedLanguages = Object.keys(languageLoaders);
+    static supportedLanguages = options.supportedLanguages || Object.keys(languageLoaders || {});
 
     static preload() {
       return ReactAsyncHighlighter.loadAstGenerator();

--- a/src/default-highlight.js
+++ b/src/default-highlight.js
@@ -1,5 +1,9 @@
 import highlight from './highlight';
 import defaultStyle from './styles/hljs/default-style';
 import lowlight from 'lowlight';
+import supportedLanguages from './languages/hljs/supported-languages';
 
-export default highlight(lowlight, defaultStyle);
+const highlighter = highlight(lowlight, defaultStyle);
+highlighter.supportedLanguages = supportedLanguages;
+
+export default highlighter;

--- a/src/prism-async.js
+++ b/src/prism-async.js
@@ -1,4 +1,5 @@
 import createAsyncLoadingHighlighter from './async-syntax-highlighter';
+import supportedLanguages from './languages/prism/supported-languages';
 
 export default createAsyncLoadingHighlighter({
   loader: () => import(
@@ -7,5 +8,6 @@ export default createAsyncLoadingHighlighter({
       // Webpack 3 returns module.exports as default as module, but webpack 4 returns module.exports as module.default
       return module.default || module;
     }),
-    noAsyncLoadingLanguages: true
+    noAsyncLoadingLanguages: true,
+    supportedLanguages,
 });

--- a/src/prism.js
+++ b/src/prism.js
@@ -2,5 +2,9 @@
 import highlight from './highlight';
 import defaultStyle from './styles/prism/prism';
 import refractor from 'refractor';
+import supportedLanguages from './languages/prism/supported-languages';
 
-export default highlight(refractor, defaultStyle);
+const highlighter = highlight(refractor, defaultStyle);;
+highlighter.supportedLanguages = supportedLanguages;
+
+export default highlighter;


### PR DESCRIPTION
Allows consumers to know what languages are supported

Same change as https://github.com/conorhastings/react-syntax-highlighter/pull/155 but hoping CI passes when not running on a fork 🤞 