### PR TITLE
Fix language directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ SyntaxHighlighter.registerLanguage('javascript', js);
 You can require `react-syntax-highlighter/prism-light` to use the prism light build instead of the standard light build. 
 ```jsx
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter/prism-light";
-import jsx from 'react-syntax-highlighter/languages/prism/jsx';
+import jsx from 'react-syntax-highlighter/dist/languages/prism/jsx';
 import prism from 'react-syntax-highlighter/dist/styles/prism/prism'; 
 
 SyntaxHighlighter.registerLanguage('jsx', jsx);


### PR DESCRIPTION
The CHANGELOG [only mentions moving styles to `/dist`](https://github.com/conorhastings/react-syntax-highlighter/blob/master/CHANGELOG.MD#1000), but since the README elsewhere also mentions that languages are in `/dist`, and the directory layout on my local install has them there as well, I figured I could update it.

If it is correct that `languages` (and `light`, `prism` and `prism-light`) have moved to `dist`, please explicitly confirm it here - that will allow me to submit [a PR to the TypeScript typings](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31154) as well :)