### PR TITLE
Update Use section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I do realize that javascript styles are not for everyone, so you can optionally 
 #### props
 
 - `language` - the language to highlight code in. Available options [here for hljs](./AVAILABLE_LANGUAGES_HLJS.MD) and [here for prism](./AVAILABLE_LANGUAGES_PRISM.MD). (pass text to just render plain monospaced text)
-- `style` - style object required from styles/hljs or styles/prism directory depending on whether or not you are importing from `react-syntax-highlighter` or `react-syntax-highlighter/prism` directory [here for hljs](./AVAILABLE_STYLES_HLJS.MD). and [here for prism](./AVAILABLE_STYLES_PRISM.MD). `import { style } from 'react-syntax-highlighter/dist/styles/{hljs|prism}'` . Will use default if style is not included.
+- `style` - style object required from styles/hljs or styles/prism directory depending on whether or not you are importing from `react-syntax-highlighter` or `react-syntax-highlighter/prism` directory [here for hljs](./AVAILABLE_STYLES_HLJS.MD). and [here for prism](./AVAILABLE_STYLES_PRISM.MD). `import { style } from 'react-syntax-highlighter/dist/esm/styles/{hljs|prism}'` . Will use default if style is not included.
 - `children` - the code to highlight.
 - `customStyle` - prop that will be combined with the top level style on the pre tag, styles here will overwrite earlier styles.
 - `codeTagProps` - props that will be spread into the `<code>` tag that is the direct parent of the highlighted code elements. Useful for styling/assigning classNames.


### PR DESCRIPTION
This commit updates location of `{hljs|prism}` in Use section of `README.md` to match changes in https://github.com/conorhastings/react-syntax-highlighter/commit/53dfcbcddb3c8a944bf39785d43eadbc1637a69a.