### PR TITLE
Modified example to match removal of lineStyle prop

### DIFF
--- a/demo/diff.js
+++ b/demo/diff.js
@@ -82,15 +82,14 @@ function DiffHighlight() {
           <SyntaxHighlighter
             style={docco}
             wrapLines={true}
-            lineStyle={lineNumber => {
+            lineProps={lineNumber => {
               let style = { display: 'block' };
               if (ADDED.includes(lineNumber)) {
                 style.backgroundColor = '#dbffdb';
-              }
-              else if (REMOVED.includes(lineNumber)) {
+              } else if (REMOVED.includes(lineNumber)) {
                 style.backgroundColor = '#ffecec';
               }
-              return style;
+              return { style };
             }}
           >
             {CODE}


### PR DESCRIPTION
There was an outdated example that uses lineStyle prop that was removed last year. I updated the example.