### PR TITLE
fix failing tests: replace ES2019 .flat() with spread + concatenate

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -253,9 +253,7 @@ function processLines(
     }
   }
 
-  if (!wrapLines) return [].concat(...newTree);
-
-  return newTree;
+  return wrapLines ? newTree : [].concat(...newTree);
 }
 
 function defaultRenderer({ rows, stylesheet, useInlineStyles }) {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -253,7 +253,9 @@ function processLines(
     }
   }
 
-  return wrapLines ? newTree : newTree.flat();
+  if (!wrapLines) return [].concat(...newTree);
+
+  return newTree;
 }
 
 function defaultRenderer({ rows, stylesheet, useInlineStyles }) {


### PR DESCRIPTION
Should fix the failing tests, which weren't expecting ES2019 syntax.