### PR TITLE
updated to use classnames when useInlineStyles true

### DIFF
--- a/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
+++ b/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
@@ -199,7 +199,7 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -215,7 +215,7 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -394,7 +394,7 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -410,7 +410,7 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/custom-code.js.snap
+++ b/__tests__/__snapshots__/custom-code.js.snap
@@ -113,7 +113,7 @@ exports[`SyntaxHighlighter component renders custom react component where code t
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -129,7 +129,7 @@ exports[`SyntaxHighlighter component renders custom react component where code t
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -308,7 +308,7 @@ exports[`SyntaxHighlighter component renders custom react component where code t
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -324,7 +324,7 @@ exports[`SyntaxHighlighter component renders custom react component where code t
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -507,7 +507,7 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -523,7 +523,7 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -702,7 +702,7 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -718,7 +718,7 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/custom-pre.js.snap
+++ b/__tests__/__snapshots__/custom-pre.js.snap
@@ -113,7 +113,7 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -129,7 +129,7 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -308,7 +308,7 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -324,7 +324,7 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -507,7 +507,7 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -523,7 +523,7 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -702,7 +702,7 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -718,7 +718,7 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/line-numbers.js.snap
+++ b/__tests__/__snapshots__/line-numbers.js.snap
@@ -232,7 +232,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -248,7 +248,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -427,7 +427,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -443,7 +443,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -745,7 +745,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -761,7 +761,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -940,7 +940,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -956,7 +956,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -1218,7 +1218,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -1234,7 +1234,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -1413,7 +1413,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -1429,7 +1429,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/no-language.js.snap
+++ b/__tests__/__snapshots__/no-language.js.snap
@@ -113,7 +113,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -129,7 +129,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -308,7 +308,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -324,7 +324,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/prism-async-light.js.snap
+++ b/__tests__/__snapshots__/prism-async-light.js.snap
@@ -200,7 +200,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
                    
     </span>
     <span
-      className="token"
+      className="token comment"
       style={
         Object {
           "color": "slategray",
@@ -221,7 +221,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -242,7 +242,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -265,7 +265,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       ans 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -281,7 +281,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token boolean"
       style={
         Object {
           "color": "#905",
@@ -304,7 +304,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -319,7 +319,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        ans
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -340,7 +340,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           question 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -356,7 +356,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token builtin"
       style={
         Object {
           "color": "#690",
@@ -366,7 +366,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       raw_input
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -376,7 +376,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       (
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -386,7 +386,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       "Ask the magic 8 ball a question: (press enter to quit) "
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -409,7 +409,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -425,7 +425,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        random
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -440,7 +440,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       randint
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -450,7 +450,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       (
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -460,7 +460,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       1
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -470,7 +470,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       ,
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -480,7 +480,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       8
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -503,7 +503,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -518,7 +518,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        question 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -534,7 +534,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -544,7 +544,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       ""
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -565,7 +565,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               sys
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -580,7 +580,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       exit
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -590,7 +590,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -613,7 +613,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -628,7 +628,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -644,7 +644,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -654,7 +654,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       1
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -675,7 +675,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -690,7 +690,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -713,7 +713,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -728,7 +728,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -744,7 +744,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -754,7 +754,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       2
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -775,7 +775,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -790,7 +790,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -813,7 +813,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -828,7 +828,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -844,7 +844,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -854,7 +854,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       3
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -875,7 +875,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -890,7 +890,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -913,7 +913,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -928,7 +928,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -944,7 +944,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -954,7 +954,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       4
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -975,7 +975,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -990,7 +990,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -1013,7 +1013,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1028,7 +1028,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1044,7 +1044,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -1054,7 +1054,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       5
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1075,7 +1075,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1090,7 +1090,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -1113,7 +1113,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1128,7 +1128,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1144,7 +1144,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -1154,7 +1154,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       6
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1175,7 +1175,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1190,7 +1190,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -1213,7 +1213,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1228,7 +1228,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1244,7 +1244,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -1254,7 +1254,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       7
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1275,7 +1275,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1290,7 +1290,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -1313,7 +1313,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
           
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1328,7 +1328,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        answers 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1344,7 +1344,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -1354,7 +1354,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
       8
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1375,7 +1375,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1390,7 +1390,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",

--- a/__tests__/__snapshots__/prism-async.js.snap
+++ b/__tests__/__snapshots__/prism-async.js.snap
@@ -128,7 +128,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
     }
   >
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -138,7 +138,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       print
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -148,7 +148,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       (
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -158,7 +158,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       'hello'
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -224,7 +224,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
     }
   >
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -250,7 +250,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -265,7 +265,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -275,7 +275,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       "react"
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -296,7 +296,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
         
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -311,7 +311,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        uniquePropHOC 
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -326,7 +326,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -336,7 +336,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       "./lib/unique-prop-hoc"
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -359,7 +359,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
         
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -374,7 +374,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -389,7 +389,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -404,7 +404,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -414,7 +414,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       React
     </span>
     <span
-      className="token token"
+      className="token class-name token punctuation"
       style={
         Object {
           "color": "#999",
@@ -424,7 +424,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       .
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -439,7 +439,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -460,7 +460,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -470,7 +470,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       constructor
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -486,7 +486,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -501,7 +501,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -522,7 +522,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                 
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -532,7 +532,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       super
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -547,7 +547,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -557,7 +557,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -578,7 +578,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                 
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -588,7 +588,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -609,7 +609,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -625,7 +625,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -640,7 +640,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -655,7 +655,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -676,7 +676,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -697,7 +697,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -718,7 +718,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -728,7 +728,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       componentDidMount
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -738,7 +738,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -753,7 +753,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -774,7 +774,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                 
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -784,7 +784,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       setTimeout
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -794,7 +794,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -804,7 +804,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -819,7 +819,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token arrow"
+      className="token arrow operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -835,7 +835,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -856,7 +856,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                     
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -866,7 +866,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -876,7 +876,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       .
     </span>
     <span
-      className="token method property-access"
+      className="token method function property-access"
       style={
         Object {
           "color": "#DD4A68",
@@ -886,7 +886,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       setState
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -896,7 +896,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -917,7 +917,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                         component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -932,7 +932,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token null nil"
+      className="token keyword null nil"
       style={
         Object {
           "color": "#07a",
@@ -953,7 +953,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                     
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -963,7 +963,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       }
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -973,7 +973,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -994,7 +994,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                 
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1004,7 +1004,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       }
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1019,7 +1019,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1029,7 +1029,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1045,7 +1045,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1066,7 +1066,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1082,7 +1082,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1092,7 +1092,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1108,7 +1108,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1129,7 +1129,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -1145,7 +1145,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -1155,7 +1155,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       1000
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1165,7 +1165,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1186,7 +1186,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1207,7 +1207,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -1217,7 +1217,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       render
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1227,7 +1227,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1242,7 +1242,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1263,7 +1263,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
                 
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1278,7 +1278,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1288,7 +1288,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1304,7 +1304,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       state
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1320,7 +1320,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
       component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1341,7 +1341,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
             
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1362,7 +1362,7 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
         
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",

--- a/__tests__/__snapshots__/prism-light.js.snap
+++ b/__tests__/__snapshots__/prism-light.js.snap
@@ -53,7 +53,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
     }
   >
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -79,7 +79,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -94,7 +94,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -104,7 +104,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       "react"
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -125,7 +125,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -140,7 +140,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        uniquePropHOC 
     </span>
     <span
-      className="token module"
+      className="token keyword module"
       style={
         Object {
           "color": "#07a",
@@ -155,7 +155,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -165,7 +165,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       "./lib/unique-prop-hoc"
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -188,7 +188,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -203,7 +203,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -218,7 +218,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -233,7 +233,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -243,7 +243,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       React
     </span>
     <span
-      className="token token"
+      className="token class-name token punctuation"
       style={
         Object {
           "color": "#999",
@@ -253,7 +253,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       .
     </span>
     <span
-      className="token"
+      className="token class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -268,7 +268,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -289,7 +289,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -299,7 +299,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       constructor
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -315,7 +315,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -330,7 +330,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -351,7 +351,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -361,7 +361,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       super
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -376,7 +376,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -386,7 +386,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -407,7 +407,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -417,7 +417,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -438,7 +438,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -454,7 +454,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -469,7 +469,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -484,7 +484,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -505,7 +505,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -526,7 +526,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -547,7 +547,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -557,7 +557,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       componentDidMount
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -567,7 +567,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -582,7 +582,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -603,7 +603,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
               
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -613,7 +613,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       setTimeout
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -623,7 +623,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -633,7 +633,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -648,7 +648,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token arrow"
+      className="token arrow operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -664,7 +664,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -685,7 +685,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
                   
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -695,7 +695,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -705,7 +705,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       .
     </span>
     <span
-      className="token method property-access"
+      className="token method function property-access"
       style={
         Object {
           "color": "#DD4A68",
@@ -715,7 +715,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       setState
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -725,7 +725,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -746,7 +746,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
                       component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -761,7 +761,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token null nil"
+      className="token keyword null nil"
       style={
         Object {
           "color": "#07a",
@@ -782,7 +782,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
                   
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -792,7 +792,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       }
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -802,7 +802,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -823,7 +823,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
               
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -833,7 +833,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       }
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -848,7 +848,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -858,7 +858,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -874,7 +874,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -895,7 +895,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -911,7 +911,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -921,7 +921,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -937,7 +937,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       props
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -958,7 +958,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -974,7 +974,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -984,7 +984,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       1000
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -994,7 +994,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1015,7 +1015,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1036,7 +1036,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -1046,7 +1046,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       render
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1056,7 +1056,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1071,7 +1071,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1092,7 +1092,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
               
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1107,7 +1107,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
        
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1117,7 +1117,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       this
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1133,7 +1133,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       state
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1149,7 +1149,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       component
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1170,7 +1170,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
           
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1191,7 +1191,7 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
       
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1257,7 +1257,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
     }
   >
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -1267,7 +1267,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       print
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -1277,7 +1277,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       (
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -1287,7 +1287,7 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       'hello'
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",

--- a/__tests__/__snapshots__/refractor.js.snap
+++ b/__tests__/__snapshots__/refractor.js.snap
@@ -53,7 +53,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
     }
   >
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -68,7 +68,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token function-variable"
+      className="token function-variable function"
       style={
         Object {
           "color": "#DD4A68",
@@ -83,7 +83,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -110,7 +110,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token arrow"
+      className="token arrow operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -126,7 +126,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        fun 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -142,7 +142,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -152,7 +152,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       1
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -173,7 +173,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -188,7 +188,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        dude 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -204,7 +204,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -214,7 +214,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       woah
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -224,7 +224,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       (
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -234,7 +234,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       2
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -249,7 +249,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -265,7 +265,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -275,7 +275,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       3
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -296,7 +296,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -311,7 +311,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -321,7 +321,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       thisIsAFunction
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -331,7 +331,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -346,7 +346,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -367,7 +367,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
         
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -382,7 +382,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -392,7 +392,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       [
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -402,7 +402,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       1
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -412,7 +412,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       ,
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -422,7 +422,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       2
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -432,7 +432,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       ,
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -442,7 +442,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       3
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -452,7 +452,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       ]
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -462,7 +462,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       .
     </span>
     <span
-      className="token method property-access"
+      className="token method function property-access"
       style={
         Object {
           "color": "#DD4A68",
@@ -472,7 +472,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       map
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -493,7 +493,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token arrow"
+      className="token arrow operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -509,7 +509,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        n 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -525,7 +525,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -535,7 +535,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       1
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -545,7 +545,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -555,7 +555,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       .
     </span>
     <span
-      className="token method property-access"
+      className="token method function property-access"
       style={
         Object {
           "color": "#DD4A68",
@@ -565,7 +565,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       filter
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -580,7 +580,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       n 
     </span>
     <span
-      className="token"
+      className="token operator"
       style={
         Object {
           "background": "hsla(0, 0%, 100%, .5)",
@@ -596,7 +596,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token number"
       style={
         Object {
           "color": "#905",
@@ -606,7 +606,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       3
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -616,7 +616,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -637,7 +637,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -658,7 +658,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token console"
+      className="token console class-name"
       style={
         Object {
           "color": "#DD4A68",
@@ -668,7 +668,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       console
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -678,7 +678,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       .
     </span>
     <span
-      className="token method property-access"
+      className="token method function property-access"
       style={
         Object {
           "color": "#DD4A68",
@@ -688,7 +688,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       log
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -698,7 +698,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       (
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -708,7 +708,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       'making up fake code is really hard'
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -718,7 +718,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       )
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -741,7 +741,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -756,7 +756,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token function"
       style={
         Object {
           "color": "#DD4A68",
@@ -766,7 +766,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       itIs
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -776,7 +776,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       (
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -791,7 +791,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -812,7 +812,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
         
     </span>
     <span
-      className="token"
+      className="token keyword"
       style={
         Object {
           "color": "#07a",
@@ -827,7 +827,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
        
     </span>
     <span
-      className="token"
+      className="token string"
       style={
         Object {
           "color": "#690",
@@ -837,7 +837,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       'no seriously really it is'
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",
@@ -858,7 +858,7 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
       
     </span>
     <span
-      className="token"
+      className="token punctuation"
       style={
         Object {
           "color": "#999",

--- a/__tests__/__snapshots__/render.js.snap
+++ b/__tests__/__snapshots__/render.js.snap
@@ -113,7 +113,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -129,7 +129,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -308,7 +308,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -324,7 +324,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/unknown-language.js.snap
+++ b/__tests__/__snapshots__/unknown-language.js.snap
@@ -113,7 +113,7 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -129,7 +129,7 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",
@@ -308,7 +308,7 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
       
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-keyword"
       style={
         Object {
           "fontWeight": "bold",
@@ -324,7 +324,7 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
        
     </span>
     <span
-      className="hljs-function"
+      className="hljs-function hljs-title"
       style={
         Object {
           "color": "#880000",

--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -136,7 +136,7 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -152,7 +152,7 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -371,7 +371,7 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -387,7 +387,7 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -618,7 +618,7 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -634,7 +634,7 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -853,7 +853,7 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -869,7 +869,7 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -1088,7 +1088,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -1104,7 +1104,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -1303,7 +1303,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
         
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -1319,7 +1319,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -1478,7 +1478,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-class"
+        className="hljs-class hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -1494,7 +1494,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-class"
+        className="hljs-class hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -1591,7 +1591,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
           
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -1607,7 +1607,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -1623,7 +1623,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -1640,7 +1640,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
         (
       </span>
       <span
-        className="hljs-function hljs-params"
+        className="hljs-function hljs-params hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -2019,7 +2019,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
           
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -2035,7 +2035,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",
@@ -2051,7 +2051,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
          
       </span>
       <span
-        className="hljs-function"
+        className="hljs-function hljs-title"
         style={
           Object {
             "color": "#880000",
@@ -2068,7 +2068,7 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
         (
       </span>
       <span
-        className="hljs-function hljs-params"
+        className="hljs-function hljs-params hljs-keyword"
         style={
           Object {
             "fontWeight": "bold",

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -48,7 +48,7 @@ export default function createElement({
     const props = useInlineStyles
       ? {
           ...properties,
-          ...{ className: className && createClassNameString(className) },
+          ...{ className: className && createClassNameString(properties.className) },
           style: createStyleObject(
             properties.className,
             Object.assign({}, properties.style, style),


### PR DESCRIPTION
for [Keep code segment classes when useInlineStyles is true #260](https://github.com/conorhastings/react-syntax-highlighter/issues/260)